### PR TITLE
feat(filament): #DEV-07 Manage Role Permissions & Seeders

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,9 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -42,10 +45,15 @@ use Spatie\Permission\Traits\HasRoles;
  *
  * @mixin \Eloquent
  */
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable, HasRoles;
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return $this->hasRole('admin');
+    }
 
     /**
      * The attributes that are mass assignable.

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Category;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $array = [
+            'Programming',
+            'UI/UX Design',
+            'Digital Marketing',
+        ];
+
+        foreach ($array as $item) {
+            Category::create([
+                'name' => $item,
+            ]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            RolePermissionSeeder::class,
+            CategorySeeder::class,
+            PricingSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PricingSeeder.php
+++ b/database/seeders/PricingSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Pricing;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class PricingSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Pricing::create([
+            'name' => 'Pro Talent',
+            'price' => 299000,
+            'duration' => 1,
+        ]);
+    }
+}

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+
+class RolePermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $adminRole = Role::create([
+            'name' => 'admin',
+        ]);
+
+        $mentorRole = Role::create([
+            'name' => 'mentor',
+        ]);
+
+        $studentRole = Role::create([
+            'name' => 'student',
+        ]);
+
+        $user = User::create([
+            'name' => 'Team Obito',
+            'email' => 'team@obito.com',
+            'password' => bcrypt('password123'),
+        ]);
+        $user->assignRole($adminRole);
+    }
+}


### PR DESCRIPTION
This pull request introduces several important changes to the `User` model and adds multiple seeders to the database. The changes enhance user role management and streamline database seeding. Below is a summary of the most significant changes:

### Enhancements to User Model:

* Implemented the `FilamentUser` interface in the `User` model to integrate with the Filament admin panel. Added the `canAccessPanel` method to restrict access to users with the 'admin' role. [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR6-R8) [[2]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbL45-R57)

### Addition of Database Seeders:

* Created `CategorySeeder` to seed the `categories` table with predefined categories: 'Programming', 'UI/UX Design', and 'Digital Marketing'.
* Created `PricingSeeder` to seed the `pricings` table with a 'Pro Talent' pricing plan.
* Created `RolePermissionSeeder` to seed roles ('admin', 'mentor', 'student') and assign the 'admin' role to a default user.

### Updates to DatabaseSeeder:

* Updated `DatabaseSeeder` to call the new seeders: `RolePermissionSeeder`, `CategorySeeder`, and `PricingSeeder`.